### PR TITLE
fix: update dependencies with vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4485,9 +4485,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "dev": true,
             "funding": [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8258,9 +8258,9 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+            "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
             "dev": true,
             "dependencies": {
                 "colorette": "^2.0.10",

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -8,11 +8,11 @@ class Constants
      * The current release version
      * Follows the Semantic Versioning strategy: https://semver.org/.
      */
-    public const string VERSION = '2.0.1';
+    public const string VERSION = '2.0.2';
     /**
      * The current release: major * 10000 + minor * 100 + patch.
      */
-    public const int VERSION_ID = 20001;
+    public const int VERSION_ID = 20002;
     /**
      * Main Website URL.
      */


### PR DESCRIPTION
- [fix: update release version](https://github.com/hippothomas/hippolyte-thomas-back/commit/c934edfd42db3d3f9dd440aeac485eb4200067e4)
- [chore(deps-dev): bump webpack-dev-middleware from 5.3.3 to 5.3.4](https://github.com/hippothomas/hippolyte-thomas-back/commit/32029956be333655d31b03067316b85c6d3b327b)
- [chore(deps-dev): bump follow-redirects from 1.15.5 to 1.15.6](https://github.com/hippothomas/hippolyte-thomas-back/commit/afbfe806020fbb01e7780941912b1c895bd0ae76)