### PR TITLE
fix: update dependencies with vulnerabilities (tinymce & ws)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11898,16 +11898,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.57",
+            "version": "1.11.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e"
+                "reference": "6ac78f1165346c83b4a753f7e4186d969c6ad0ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1627b1d03446904aaa77593f370c5201d2ecc34e",
-                "reference": "1627b1d03446904aaa77593f370c5201d2ecc34e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6ac78f1165346c83b4a753f7e4186d969c6ad0ee",
+                "reference": "6ac78f1165346c83b4a753f7e4186d969c6ad0ee",
                 "shasum": ""
             },
             "require": {
@@ -11950,13 +11950,9 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-01-24T11:51:34+00:00"
+            "time": "2024-07-01T15:33:06+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "license": "MIT",
             "dependencies": {
                 "air-datepicker": "^3.4.0",
-                "tinymce": "^7.0.0",
+                "tinymce": "^7.2.0",
                 "tom-select": "^2.3.1"
             },
             "devDependencies": {
@@ -7906,9 +7906,9 @@
             "dev": true
         },
         "node_modules/tinymce": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.0.0.tgz",
-            "integrity": "sha512-ggXLfTRrUALAcjeJSRrZcJDOl6MgC2tPXe/zNOEkQXvTDgcKqFypPRoPpfpK5wejexjyaI/7dwETOntJ5MPBFg=="
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-7.2.0.tgz",
+            "integrity": "sha512-R460NlE4REIFuLcZd9mpHK8zRsHdOueLV2m6Wsn0JHfGhDWMcfB1IqUX2QGrSbJga93ygJbJbNMwb2sakFlE/g=="
         },
         "node_modules/tmp": {
             "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8495,9 +8495,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "air-datepicker": "^3.4.0",
-        "tinymce": "^7.0.0",
+        "tinymce": "^7.2.0",
         "tom-select": "^2.3.1"
     }
 }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -8,11 +8,11 @@ class Constants
      * The current release version
      * Follows the Semantic Versioning strategy: https://semver.org/.
      */
-    public const string VERSION = '2.0.3';
+    public const string VERSION = '2.0.4';
     /**
      * The current release: major * 10000 + minor * 100 + patch.
      */
-    public const int VERSION_ID = 20003;
+    public const int VERSION_ID = 20004;
     /**
      * Main Website URL.
      */

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -40,8 +40,8 @@ abstract class ApiTestCase extends WebTestCase
             return $property->name;
         }, $cls->getProperties());
         // Remove false value
-        $properties = array_filter($properties, function ($e) {
-            return $e;
+        $properties = array_filter($properties, function (string|false $e) {
+            return false !== $e;
         });
 
         // Check if each class property is present in our JSON Object


### PR DESCRIPTION
- [chore(deps): bump tinymce from 7.0.0 to 7.2.0](https://github.com/hippothomas/hippolyte-thomas-back/commit/296462a941023c04b05d313b2cf07086d8630e97)
- [chore(deps-dev): bump ws from 8.16.0 to 8.17.1](https://github.com/hippothomas/hippolyte-thomas-back/commit/da63aabe2807ace396f148c6c05dcb3c83ce8fd9)
- [fix: update release version](https://github.com/hippothomas/hippolyte-thomas-back/commit/9fb2c401365cf9542a896c9912f7e090d6335d3e)
- [fix: PHPStan analysis in last version](https://github.com/hippothomas/hippolyte-thomas-back/pull/26/commits/0f8774929f81b0d4756fc4f2ea8fe7867da091d6)